### PR TITLE
Make priority reusable downstream.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ class SomeWorker
   include Sidekiq::Apriori::Worker
 
   def perform
-    with_priority do |priority|
+    with_priority do |priority = nil|
       OtherWorker.perform_async(priority: priority)
     end
   end

--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ a priority designation.
 If you're not using ruby 2, you'll need to redefine your perform method to take an
 additional, optional argument
 
+Since ruby 2 may possibly strip away the `{priority: ...}` option passed to the
+```perform``` method, it provides ```with_priortity``` to compensate for it:
+
+```ruby
+class SomeWorker
+  include Sidekiq::Apriori::Worker
+
+  def perform
+    with_priority do |priority|
+      OtherWorker.perform_async(priority: priority)
+    end
+  end
+end
+```
+
 License
 -------
 

--- a/lib/sidekiq-apriori/worker.rb
+++ b/lib/sidekiq-apriori/worker.rb
@@ -18,22 +18,29 @@ module Sidekiq::Apriori
       extract_priority!(args.last)
       super(*args)
     rescue ArgumentError => err
-      raise err unless has_priority?
+      raise err unless has_declared_priority?
       super(*args[0..-2])
     end
 
     def with_priority
-      yield(@_apriori_priority)
+      yield(@apriori_priority_args.last)
     end
 
-    def has_priority?
-      !!@_apriori_priority
+    def has_declared_priority?
+      @apriori_priority_args.first
     end
-    private :has_priority?
+    private :has_declared_priority?
 
     def extract_priority!(options)
+      @apriori_priority_args = []
+
       return unless hashlike?(options)
-      @_apriori_priority = stringify_keys(options)['priority']
+      s_opts = stringify_keys(options)
+
+      @apriori_priority_args = [
+        s_opts.has_key?('priority'),
+        s_opts['priority']
+      ]
     end
     private :extract_priority!
 

--- a/lib/sidekiq-apriori/worker.rb
+++ b/lib/sidekiq-apriori/worker.rb
@@ -31,7 +31,7 @@ module Sidekiq::Apriori
     end
 
     def has_declared_priority?
-      @apriori_priority_args.first
+      (@apriori_priority_args || []).first
     end
     private :has_declared_priority?
 

--- a/lib/sidekiq-apriori/worker.rb
+++ b/lib/sidekiq-apriori/worker.rb
@@ -23,7 +23,11 @@ module Sidekiq::Apriori
     end
 
     def with_priority
-      yield(@apriori_priority_args.last)
+      if has_declared_priority?
+        yield(@apriori_priority_args.last)
+      else
+        yield
+      end
     end
 
     def has_declared_priority?

--- a/lib/sidekiq-apriori/worker.rb
+++ b/lib/sidekiq-apriori/worker.rb
@@ -13,18 +13,29 @@ module Sidekiq::Apriori
   end
 
   module ClassMethods
+
     def perform(*args)
+      extract_priority!(args.last)
       super(*args)
     rescue ArgumentError => err
-      raise err unless has_priority?(args.last)
+      raise err unless has_priority?
       super(*args[0..-2])
     end
 
-    def has_priority?(options)
-      return false unless hashlike?(options)
-      stringify_keys(options).has_key?('priority')
+    def with_priority
+      yield(@_apriori_priority)
+    end
+
+    def has_priority?
+      !!@_apriori_priority
     end
     private :has_priority?
+
+    def extract_priority!(options)
+      return unless hashlike?(options)
+      @_apriori_priority = stringify_keys(options)['priority']
+    end
+    private :extract_priority!
 
     def stringify_keys(hashish)
       duplicate = hashish.dup

--- a/spec/sidekiq-apriori/worker_spec.rb
+++ b/spec/sidekiq-apriori/worker_spec.rb
@@ -4,7 +4,14 @@ require 'sidekiq-apriori/worker'
 describe Sidekiq::Apriori::Worker do
   before(:all) do
     class Job
-      def perform; end
+      attr_accessor :captured_priority
+
+      def perform
+        with_priority do |priority|
+          self.captured_priority = priority
+        end
+      end
+
       include Sidekiq::Apriori::Worker
     end
   end
@@ -24,4 +31,12 @@ describe Sidekiq::Apriori::Worker do
       expect { job.perform({}) }.to raise_error(ArgumentError)
     end
   end
+
+  ## Make priority available
+  #
+  it "makes priority available" do
+    job.perform(priority: "critical")
+    expect(job.captured_priority).to eq("critical")
+  end
+
 end

--- a/spec/sidekiq-apriori/worker_spec.rb
+++ b/spec/sidekiq-apriori/worker_spec.rb
@@ -30,13 +30,11 @@ describe Sidekiq::Apriori::Worker do
       expect { job.perform("high") }.to raise_error(ArgumentError)
       expect { job.perform({}) }.to raise_error(ArgumentError)
     end
-  end
 
-  ## Make priority available
-  #
-  it "makes priority available" do
-    job.perform(priority: "critical")
-    expect(job.captured_priority).to eq("critical")
+    it "makes priority available" do
+      job.perform(priority: "critical")
+      expect(job.captured_priority).to eq("critical")
+    end
   end
 
 end

--- a/spec/sidekiq-apriori/worker_spec.rb
+++ b/spec/sidekiq-apriori/worker_spec.rb
@@ -7,7 +7,7 @@ describe Sidekiq::Apriori::Worker do
       attr_accessor :captured_priority
 
       def perform
-        with_priority do |priority|
+        with_priority do |priority = :low|
           self.captured_priority = priority
         end
       end
@@ -21,7 +21,7 @@ describe Sidekiq::Apriori::Worker do
   ## Checking for ruby 2
   #
   if ( RUBY_VERSION.split(/\./).map(&:to_i) rescue [] ).first > 1
-    it "redefines 'perform' to handle an extra argument when that argument has priority information" do
+    it "re 'perform' to handle an extra argument when that argument has priority information" do
       expect(job).to be_an_instance_of(Job)
       expect { job.perform(priority: "high") }.not_to raise_error
     end
@@ -31,9 +31,14 @@ describe Sidekiq::Apriori::Worker do
       expect { job.perform({}) }.to raise_error(ArgumentError)
     end
 
-    it "makes priority available" do
+    it "makes priority available if specified" do
       job.perform(priority: "critical")
       expect(job.captured_priority).to eq("critical")
+    end
+
+    it "makes priority available if specified" do
+      job.perform
+      expect(job.captured_priority).to eq(:low)
     end
   end
 


### PR DESCRIPTION
Added support for the following use case:

```
class SomeWorker
  include Sidekiq::Apriori::Worker

  def perform
    with_priority do |priority|
      OtherWorker.perform_async(priority: priority)
    end
  end
end
```
