### PR TITLE
Fix the gem name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Installation
 
 Manual installation is always an option. From the command line:
 
-    $ gem install sidekiq-priority
+    $ gem install sidekiq-apriori
 
 Or, if you're using bundler, simply include it in your Gemfile:
 
-    gem 'sidekiq-priority'
+    gem 'sidekiq-apriori'
 
 Priorities
 ----------


### PR DESCRIPTION
Seriously, the right gem name is sidekiq-apriori, not a sidekiq-priority
